### PR TITLE
Deserialize and deconstruct `Notify` method call arguments in one go.

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -1,7 +1,0 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Action {
-    pub identifier: String,
-    pub description: String,
-}

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,7 +1,7 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Action {
-    pub name: String,
-    pub method: String,
+    pub identifier: String,
+    pub description: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,10 @@ pub async fn listen_to_dbus_notifications(
         .await
         .unwrap();
 
-    MessageStream::from(monitor.connection())
-        .map(|message| {
-            let message = Arc::try_unwrap(message?).unwrap(); // Extract the Message from the Arc, I'm not sure whether this will work or not. Todo: try to find a better way of doing this
-            let notification = message.try_into()?;
-            debug!(?notification, "adding notification to stream");
-            Ok(notification)
-        })
+    MessageStream::from(monitor.connection()).map(|message| {
+        let message = Arc::try_unwrap(message?).unwrap(); // Extract the Message from the Arc, I'm not sure whether this will work or not. Todo: try to find a better way of doing this
+        let notification = message.try_into()?;
+        debug!(?notification, "adding notification to stream");
+        Ok(notification)
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ use std::{error::Error, ops::Deref, sync::Arc};
 use tracing::{debug, info, instrument};
 
 use zbus::{fdo::MonitoringProxy, Connection, MatchRule, MessageStream, MessageType};
-mod action;
 mod notification;
 use notification::Notification;
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -2,87 +2,36 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use zbus::{
-    zvariant::{Type, Value},
-    Message,
-};
-
-use action::Action;
-
-use crate::action;
+use zbus::{zvariant::Value, Message};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Notification {
     pub app_name: String,
     pub title: String,
     pub body: String,
-    pub actions: Vec<Action>,
 }
 
-// This struct is used to deserialize the body of the `Notify`` method call message.
-// The notification spec: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
-#[derive(Debug, PartialEq, Serialize, Deserialize, Type)]
-struct NotifyArgs<'a> {
-    // Human readable app_name.
-    app_name: String,
-
-    // Replaces an existing notification.
-    replace_id: u32,
-
-    // The app_icon is displayed next to the notification.
-    // Further reading: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#icons-and-images
-    app_icon: String,
-
-    // Brief summary of the notification.
-    summary: String,
-
-    // Detailed body text.
-    body: String,
-
-    // 	Actions as a list of pairs: Action identifier, localized string that will be displayed.
-    actions: Vec<String>,
-
-    // 	Hints as a dictionary. See hints section for more details.
-    #[serde(borrow)]
-    hints: HashMap<String, Value<'a>>,
-
-    // Timeout time in milliseconds
-    expire_timeout: i32,
-}
+type MessageBody<'a> = (
+    String,
+    u32,
+    &'a str,
+    String,
+    String,
+    Vec<&'a str>,
+    HashMap<&'a str, Value<'a>>,
+    i32,
+);
 
 impl TryFrom<Message> for Notification {
     type Error = zbus::Error;
 
     fn try_from(value: Message) -> Result<Self, Self::Error> {
-        let NotifyArgs {
-            app_name,
-            summary,
-            body,
-            actions,
-            ..
-        } = value.body()?;
-
-        let actions = actions
-            .chunks(2)
-            .filter_map(|pair| {
-                // We expect the actions to be a list of pairs as described in the spec.
-                // If the list is not a multiple of 2, we ignore the last element.
-                let [identifier, localized_description] = pair else {
-                    return None;
-                };
-
-                Some(Action {
-                    identifier: identifier.to_owned(),
-                    description: localized_description.to_owned(),
-                })
-            })
-            .collect();
+        let (app_name, _, _, title, body, ..) = value.body::<MessageBody>()?;
 
         Ok(Notification {
             app_name,
-            title: summary,
+            title,
             body,
-            actions,
         })
     }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use zbus::{zvariant::Value, Message};
+use zbus::{
+    zvariant::{Type, Value},
+    Message,
+};
 
 use action::Action;
 
@@ -15,27 +18,63 @@ pub struct Notification {
     pub body: String,
     pub actions: Vec<Action>,
 }
-type RawNotifyMethodSignature<'a> = (
-    String,
-    u32,
-    String,
-    String,
-    String,
-    Vec<String>,
-    HashMap<String, Value<'a>>,
-    i32,
-);
+
+// This struct is used to deserialize the body of the `Notify`` method call message.
+// The notification spec: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+#[derive(Debug, PartialEq, Serialize, Deserialize, Type)]
+struct NotifyArgs<'a> {
+    // Human readable app_name.
+    app_name: String,
+
+    // Replaces an existing notification.
+    replace_id: u32,
+
+    // The app_icon is displayed next to the notification.
+    // Further reading: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#icons-and-images
+    app_icon: String,
+
+    // Brief summary of the notification.
+    summary: String,
+
+    // Detailed body text.
+    body: String,
+
+    // 	Actions as a list of pairs: Action identifier, localized string that will be displayed.
+    actions: Vec<String>,
+
+    // 	Hints as a dictionary. See hints section for more details.
+    #[serde(borrow)]
+    hints: HashMap<String, Value<'a>>,
+
+    // Timeout time in milliseconds
+    expire_timeout: i32,
+}
+
 impl TryFrom<Message> for Notification {
     type Error = zbus::Error;
 
     fn try_from(value: Message) -> Result<Self, Self::Error> {
-        let (app_name, _, _, summary, body, actions, _, _): RawNotifyMethodSignature =
-            value.body()?;
+        let NotifyArgs {
+            app_name,
+            summary,
+            body,
+            actions,
+            ..
+        } = value.body()?;
+
         let actions = actions
-            .into_iter()
-            .map(|action| Action {
-                name: action,
-                method: "".into(), // We don't have the method info here
+            .chunks(2)
+            .filter_map(|pair| {
+                // We expect the actions to be a list of pairs as described in the spec.
+                // If the list is not a multiple of 2, we ignore the last element.
+                let [identifier, localized_description] = pair else {
+                    return None;
+                };
+
+                Some(Action {
+                    identifier: identifier.to_owned(),
+                    description: localized_description.to_owned(),
+                })
             })
             .collect();
 

--- a/tests/recieve_notifications.rs
+++ b/tests/recieve_notifications.rs
@@ -22,12 +22,12 @@ async fn test_listen_to_dbus_notifications() -> Result<(), Box<dyn Error>> {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Send a Notification to see if it's correctly recieved on the other side
-Notification::new()
-.appname("test-notify")
-.summary("test summary")
-.body("test body")
-.show_async()
-.await?;
+    Notification::new()
+        .appname("test-notify")
+        .summary("test summary")
+        .body("test body")
+        .show_async()
+        .await?;
     // Await the listener task
     listener_task.await?.unwrap();
     Ok(())

--- a/tests/recieve_notifications.rs
+++ b/tests/recieve_notifications.rs
@@ -15,7 +15,6 @@ async fn test_listen_to_dbus_notifications() -> Result<(), Box<dyn Error>> {
         assert_eq!(notification.app_name, "test-notify");
         assert_eq!(notification.body, "test body");
         assert_eq!(notification.title, "test summary");
-        assert!(notification.actions.is_empty());
         Ok::<(), Box<dyn Error + Send>>(())
     });
     // Delay sending the notification


### PR DESCRIPTION
Your question in chat was how to deserialize the 'actions:` field directly into a `Vec<Actions>`.
We unfortunately cannot because the signature says the field is 'as' (Array of Strings).
Nothing in that description guarantees complete actions. Would it have said 'a(ss)', we could have.

This commit does the next best thing:

- Remove `RawNotifySignature<'a>` as we no longer need it.

- Adjusts `Action` fields to resemble with what specs say about `Notify.actions` method call arguments.

	See: [Notification specifications](https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#commands):
	Actions are sent over as a list of pairs: the identifier for the
	action and he localized string that will be displayed to the user.

Before the `Actions` fields (name, method) were possibly meant 
for the invocation of the `Action` (?).

- Introduce `NotifyArgs` struct that holds and names the arguments to the `Notify` method call we are monitoring for.
- Make sure to derive `Type` + `Deserialize` on `NotifyArgs`.
 - Adjust `TryFrom<Message> for Notification` to simplify deserialisation and deconstruction of the `Message::body`.

 Since we have `NotifyArgs` struct and it has the `Type + Deserialize` traits, we can now simply

 ```Rust
 let notify_args = msg.body::<NotifyArgs>body()?;
 ```

 since we are interested in just a few fields, we can selectively
 deconstruct in one go:

 ```Rust
 let NotifyArgs { app_name, summary, body, actions, .. } = msg.body()?;
```

(- Format lib.rs)

Just take whatever you find useful.