### PR TITLE
Avoid extraction by `TryFrom<Messages>` into `TryFrom<Arc<Message>>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use futures::{Stream, StreamExt};
-use std::sync::Arc;
 use tracing::{debug, info, instrument};
 
 use zbus::{fdo::MonitoringProxy, Connection, MatchRule, MessageStream, MessageType};
@@ -33,8 +32,7 @@ pub async fn listen_to_dbus_notifications() -> Result<impl Stream<Item = Notific
     monitor.become_monitor(&[notify_rule.as_str()], 0).await?;
 
     let stream = MessageStream::from(monitor.connection()).filter_map(move |message| async {
-        let message = Arc::into_inner(message.ok()?)?; // Extract the Message from the Arc, I'm not sure whether this will work or not. Todo: try to find a better way of doing this
-        let notification = message.try_into().ok()?;
+        let notification = message.ok()?.try_into().ok()?;
         debug!(?notification, "adding notification to stream");
         Some(notification)
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use futures::{Stream, StreamExt};
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 use tracing::{debug, info, instrument};
 
 use zbus::{fdo::MonitoringProxy, Connection, MatchRule, MessageStream, MessageType};
@@ -30,7 +30,7 @@ pub async fn listen_to_dbus_notifications() -> Result<impl Stream<Item = Notific
     debug!(?notify_rule, "finished generating rule");
     info!("listening for notifications");
     let notify_rule = notify_rule.to_string();
-    monitor.become_monitor(&[notify_rule.deref()], 0).await?;
+    monitor.become_monitor(&[notify_rule.as_str()], 0).await?;
 
     let stream = MessageStream::from(monitor.connection()).filter_map(move |message| async {
         let message = Arc::into_inner(message.ok()?)?; // Extract the Message from the Arc, I'm not sure whether this will work or not. Todo: try to find a better way of doing this

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
@@ -22,11 +22,11 @@ type MessageBody<'a> = (
     i32,
 );
 
-impl TryFrom<Message> for Notification {
+impl TryFrom<Arc<Message>> for Notification {
     type Error = zbus::Error;
 
-    fn try_from(value: Message) -> Result<Self, Self::Error> {
-        let (app_name, _, _, title, body, ..) = value.body::<MessageBody>()?;
+    fn try_from(msg: Arc<Message>) -> Result<Self, Self::Error> {
+        let (app_name, _, _, title, body, ..) = msg.body::<MessageBody>()?;
 
         Ok(Notification {
             app_name,

--- a/tests/receive_notifications.rs
+++ b/tests/receive_notifications.rs
@@ -20,7 +20,7 @@ async fn test_listen_to_dbus_notifications() -> Result<(), Box<dyn Error>> {
     // Delay sending the notification
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    // Send a Notification to see if it's correctly recieved on the other side
+    // Send a Notification to see if it's correctly received on the other side
     Notification::new()
         .appname("test-notify")
         .summary("test summary")


### PR DESCRIPTION
This PR does three things in two commits.

Avoid extraction from `Arc` by `TryFrom<Messages>` into `TryFrom<Arc<Message>>` by changing the conversion `TryFrom<Message>` to `TryFrom<Arc<Message>>` to avoid the need to extract from `Arc`.

- 'Recieve' is spelt 'receive': fix comment and rename test file.

- Fix need for `Deref` by using `String::as_str()` instead of `Deref::deref()`. `.as_str()` is cleaner. 
(The deref()  was introduced by me earlier)
